### PR TITLE
Fix path issues in virtual host monster environment.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix path issues in virtual host monster environment. [jone]
 
 1.0.0 (2018-06-21)
 ------------------


### PR DESCRIPTION
The method `absolute_url_path` does not return the absolute path of the object but the absolute path in the context of the current virtual host monster configuration. So it may not return the expected path. It should therefore be avoided.