### PR TITLE
Improved zip file detection

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Improved ZIP file detection [Nachtalb]
 
 
 1.1.1 (2018-07-24)


### PR DESCRIPTION
Zip files in plone can have `application/x-zip-compressed` instead of
the default `application/zip` mimetype and thus were not recognized.
Additionally now it's also possible that the file is detected as a zip
even when the file extension is wrong.